### PR TITLE
Hardware is a mass noun. It has no plural.

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       <div class="row">
         <div class="col-xs-10 col-xs-offset-1 col-sm-8 col-sm-offset-2">
           <p>Waydroid uses Linux namespaces (user, pid, uts, net, mount, ipc) to run a full Android system in a container and provide Android applications on any GNU/Linux-based platform.</p>
-          <p>The Android inside the container has direct access to needed hardwares.</p>
+          <p>The Android inside the container has direct access to needed hardware.</p>
           <p>The Android runtime environment ships with a minimal customized Android system image based on <a href="https://lineageos.org/" target="blank">LineageOS</a>. The used image is currently based on Android 10</p>
           <h3 class="display-3 text-center">&nbsp;</h3>
         </div><!-- /.col -->


### PR DESCRIPTION
Hi there. I noticed this tiny grammar issue, and thought I could help out by correcting it.

Mass nouns in English are one of the oddest features of the language. They are non-obvious to a non-native speaker, but to a native speaker the use of one of them in the plural really stands out.