### PR TITLE
Don't make image requests on scroll

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -13,13 +13,6 @@
       ud_header.classList.remove("sticky");
     }
 
-    // === logo change
-    if (ud_header.classList.contains("sticky")) {
-      logo.src = "assets/images/logo/waydroid_icon_sm.png";
-    } else {
-      logo.src = "assets/images/logo/waydroid_icon_sm.png";
-    }
-
     // show or hide the back-top-top button
     const backToTop = document.querySelector(".back-to-top");
     if (


### PR DESCRIPTION
I noticed while looking at the Network tab in my browser that it was making many seemingly bogus requests while scrolling on the page. I tracked it down to the lines of code which I have removed in the PR. The lines don't look like they have any function and just cause the browser to emit useless requests.

![image](https://github.com/waydroid/waydroid.github.io/assets/113905856/8f0a50a3-eee6-439e-b9ea-259b46815714)
